### PR TITLE
Include other files in the npm package

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,8 @@
 {
     "name": "blist-bs",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "repository": "https://github.com/raftario/blist",
     "author": "Raphaël Thériault <raphael_theriault@outlook.com>",
     "license": "MIT",
@@ -11,7 +12,7 @@
         "prepublishOnly": "node copySchema.js && tsc"
     },
     "files": [
-        "./dist/*"
+        "dist/*"
     ],
     "dependencies": {
         "adm-zip": "^0.4.0",


### PR DESCRIPTION
By removing the `./` in the `files` field it will include the two other missing files (`playlist.schema.json` and `index.d.ts`) in the npm package. You can check this difference using `npm pack` before and after the code change.